### PR TITLE
- Helper Class Created For BsonDoc Convert to Json

### DIFF
--- a/src/NebulaPlugin.Application/Helper.cs
+++ b/src/NebulaPlugin.Application/Helper.cs
@@ -1,0 +1,38 @@
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+
+namespace NebulaPlugin.Application
+{
+    public static class Helper
+    {
+        /// <summary>
+        /// BsonDocument listesini json'a çevirir. Örneğin koleksiyona bağlı değerleri json olarak çıktı almak için kullanılır.
+        /// </summary>
+        /// <param name="items">Değerler</param>
+        /// <returns></returns>
+        public static string ConvertBsonDocumentToJson(List<BsonDocument> items)
+        {
+            string jsonOutput = "";
+            foreach (var doc in items)
+            {
+                var bsonDocument = BsonDocument.Parse(doc.ToJson());
+                var settings = new JsonWriterSettings { Indent = true };
+                jsonOutput += bsonDocument.ToJson(settings);
+            }
+            return jsonOutput;
+        }
+
+        /// <summary>
+        /// BsonDocument tipini json çıktı olarak verir
+        /// </summary>
+        /// <param name="doc">Json'a çevirilmek istenen BsonDocument değişkeni</param>
+        /// <returns></returns>
+        public static string ConvertBsonDocumentToJson(BsonDocument doc)
+        {
+            var bsonDocument = BsonDocument.Parse(doc.ToJson());
+            var settings = new JsonWriterSettings { Indent = true };
+            var jsonOutput = bsonDocument.ToJson(settings);
+            return jsonOutput;
+        }
+    }
+}


### PR DESCRIPTION
- Veritabanları, koleksiyonlar için ve koleksiyonlara bağlı değerleri api üzerinden BsonDocument olarak aldığımız için request attığımızda web üzerinden bson tipini json tipine doğru bir şekilde çeviremiyorduk. Bu yüzden Helper sınıfı oluşturup bu sınıf içerisinde overload methodlar oluşturdum. Bir tanesi veritabanı, koleksiyon veya belirli bir itemi json'a çevirmek için diğeri ise bir BsonDocument listesini json'a çevirmek için. 